### PR TITLE
grafana-agent-tempo: allow tempo_additional_endpoints and tempo_attributes to be empty

### DIFF
--- a/grafana-agent-tempo/agent-daemonset.yaml
+++ b/grafana-agent-tempo/agent-daemonset.yaml
@@ -9,7 +9,9 @@ tempo:
           basic_auth = (TEMPO_USERNAME != "") ? { username = TEMPO_USERNAME, password = "$${TEMPO_PASSWORD}" } : {},
           retry_on_failure = { enabled = TEMPO_ENDPOINT_RETRY_ON_FAILURE}
         }], (TEMPO_ADDITIONAL_ENDPOINTS != []) ? TEMPO_ADDITIONAL_ENDPOINTS : []))}
+        %{~ if jsonencode(TEMPO_ATTRIBUTES) != "{}" ~}
         attributes: ${jsonencode(TEMPO_ATTRIBUTES)}
+        %{~ endif}
         batch:
             send_batch_size: 1000
             timeout: 5s

--- a/grafana-agent-tempo/grafana_agent_tempo.tf
+++ b/grafana-agent-tempo/grafana_agent_tempo.tf
@@ -20,9 +20,11 @@ variable "tempo_password" {
 }
 variable "tempo_additional_endpoints" {
   type        = list(any)
+  default     = []
   description = "Additional endpoints to configure"
 }
 variable "tempo_attributes" {
   type        = map(any)
+  default     = {}
   description = "Attributes to set for all endpoints."
 }


### PR DESCRIPTION
`tempo_attributes` is a bit tricky - if we only specify `attributes`
without a map containing `actions`, grafana-agent gets angry:

> failed to create tempo instance default: failed to create pipeline: failed to create pipelines builder: error creating processor "attributes" in pipeline "traces": error creating "attributes" processor due to missing required field "actions" of processor "attributes"

So only set attributes if TEMPO_ATTRIBUTES isn't empty. For some reason,
the comparison on the empty map didn't work, so we compare the
jsonencoded string.