### PR TITLE
update grafana agent to v0.15.0

### DIFF
--- a/modules/grafana-agent-loki/README.md
+++ b/modules/grafana-agent-loki/README.md
@@ -4,7 +4,7 @@ This deploys grafana-agent for logs forwarding into the cluster.
 
 Upstream refers to a shell script in
 https://github.com/grafana/agent/#getting-started, which will essentially just
-`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.12.0/production/kubernetes/agent-loki.yaml).
+`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.15.0/production/kubernetes/agent-loki.yaml).
 
 To properly track their lifecycle, they have been converted to terraform
 resources, using `t2fs`.

--- a/modules/grafana-agent-loki/README.md
+++ b/modules/grafana-agent-loki/README.md
@@ -4,7 +4,7 @@ This deploys grafana-agent for logs forwarding into the cluster.
 
 Upstream refers to a shell script in
 https://github.com/grafana/agent/#getting-started, which will essentially just
-`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.15.0/production/kubernetes/agent-loki.yaml).
+`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.16.0/production/kubernetes/agent-loki.yaml).
 
 To properly track their lifecycle, they have been converted to terraform
 resources, using `t2fs`.

--- a/modules/grafana-agent-loki/daemonset.tf
+++ b/modules/grafana-agent-loki/daemonset.tf
@@ -69,7 +69,7 @@ resource "kubernetes_daemonset" "grafana_agent_logs" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:main-c7ac289"
+          image   = "grafana/agent:v0.15.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-loki/daemonset.tf
+++ b/modules/grafana-agent-loki/daemonset.tf
@@ -69,7 +69,7 @@ resource "kubernetes_daemonset" "grafana_agent_logs" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.15.0"
+          image   = "grafana/agent:v0.16.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-tempo/README.md
+++ b/modules/grafana-agent-tempo/README.md
@@ -4,7 +4,7 @@ This deploys grafana-agent for traces forwarding into the cluster.
 
 Upstream refers to a shell script in
 https://github.com/grafana/agent/#getting-started, which will essentially just
-`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.15.0/production/kubernetes/agent-tempo.yaml).
+`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.16.0/production/kubernetes/agent-tempo.yaml).
 
 To properly track their lifecycle, they have been converted to terraform
 resources, using `t2fs`.

--- a/modules/grafana-agent-tempo/README.md
+++ b/modules/grafana-agent-tempo/README.md
@@ -4,7 +4,7 @@ This deploys grafana-agent for traces forwarding into the cluster.
 
 Upstream refers to a shell script in
 https://github.com/grafana/agent/#getting-started, which will essentially just
-`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.12.0/production/kubernetes/agent-tempo.yaml).
+`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.15.0/production/kubernetes/agent-tempo.yaml).
 
 To properly track their lifecycle, they have been converted to terraform
 resources, using `t2fs`.

--- a/modules/grafana-agent-tempo/daemonset.tf
+++ b/modules/grafana-agent-tempo/daemonset.tf
@@ -50,7 +50,7 @@ resource "kubernetes_daemonset" "grafana_agent_traces" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:main-c7ac289"
+          image   = "grafana/agent:v0.15.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-tempo/daemonset.tf
+++ b/modules/grafana-agent-tempo/daemonset.tf
@@ -50,7 +50,7 @@ resource "kubernetes_daemonset" "grafana_agent_traces" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.15.0"
+          image   = "grafana/agent:v0.16.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent/README.md
+++ b/modules/grafana-agent/README.md
@@ -4,7 +4,7 @@ This deploys grafana-agent for metrics collection into the cluster.
 
 Upstream refers to a shell script in
 https://github.com/grafana/agent/#getting-started, which will essentially just
-`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.15.0/production/kubernetes/agent.yaml).
+`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.16.0/production/kubernetes/agent.yaml).
 
 To properly track their lifecycle, they have been converted to terraform
 resources, using `t2fs`.

--- a/modules/grafana-agent/README.md
+++ b/modules/grafana-agent/README.md
@@ -4,7 +4,7 @@ This deploys grafana-agent for metrics collection into the cluster.
 
 Upstream refers to a shell script in
 https://github.com/grafana/agent/#getting-started, which will essentially just
-`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.12.0/production/kubernetes/agent.yaml).
+`envsubst` [a long manifests file](https://github.com/grafana/agent/blob/v0.15.0/production/kubernetes/agent.yaml).
 
 To properly track their lifecycle, they have been converted to terraform
 resources, using `t2fs`.

--- a/modules/grafana-agent/daemonset.tf
+++ b/modules/grafana-agent/daemonset.tf
@@ -46,7 +46,7 @@ resource "kubernetes_daemonset" "grafana_agent_daemonset" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:main-c7ac289"
+          image   = "grafana/agent:v0.15.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 

--- a/modules/grafana-agent/daemonset.tf
+++ b/modules/grafana-agent/daemonset.tf
@@ -46,7 +46,7 @@ resource "kubernetes_daemonset" "grafana_agent_daemonset" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.15.0"
+          image   = "grafana/agent:v0.16.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 

--- a/modules/grafana-agent/deployment.tf
+++ b/modules/grafana-agent/deployment.tf
@@ -47,7 +47,7 @@ resource "kubernetes_deployment" "grafana_agent_deployment" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.15.0"
+          image   = "grafana/agent:v0.16.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 

--- a/modules/grafana-agent/deployment.tf
+++ b/modules/grafana-agent/deployment.tf
@@ -47,7 +47,7 @@ resource "kubernetes_deployment" "grafana_agent_deployment" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:main-c7ac289"
+          image   = "grafana/agent:v0.15.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 


### PR DESCRIPTION
Fixes #1

None of the migration changes apply here:
https://github.com/grafana/agent/blob/v0.15.0/docs/migration-guide.md