### PR TITLE
Support configuring pipeline_stage

### DIFF
--- a/modules/grafana-agent-loki/agent-daemonset.yaml
+++ b/modules/grafana-agent-loki/agent-daemonset.yaml
@@ -8,7 +8,7 @@ loki:
             kubernetes_sd_configs:
               - role: pod
             pipeline_stages:
-              - docker: {}
+              - ${pipeline_stage}: {}
             relabel_configs:
               - source_labels:
                   - __meta_kubernetes_pod_label_name
@@ -51,7 +51,7 @@ loki:
             kubernetes_sd_configs:
               - role: pod
             pipeline_stages:
-              - docker: {}
+              - ${pipeline_stage}: {}
             relabel_configs:
               - action: drop
                 regex: .+
@@ -98,7 +98,7 @@ loki:
             kubernetes_sd_configs:
               - role: pod
             pipeline_stages:
-              - docker: {}
+              - ${pipeline_stage}: {}
             relabel_configs:
               - action: drop
                 regex: .+
@@ -151,7 +151,7 @@ loki:
             kubernetes_sd_configs:
               - role: pod
             pipeline_stages:
-              - docker: {}
+              - ${pipeline_stage}: {}
             relabel_configs:
               - action: drop
                 regex: .+
@@ -206,7 +206,7 @@ loki:
             kubernetes_sd_configs:
               - role: pod
             pipeline_stages:
-              - docker: {}
+              - ${pipeline_stage}: {}
             relabel_configs:
               - action: drop
                 regex: ""

--- a/modules/grafana-agent-loki/agent-loki.tf
+++ b/modules/grafana-agent-loki/agent-loki.tf
@@ -7,3 +7,9 @@ variable "loki_password" {
 variable "loki_hostname" {
   type = string
 }
+variable "pipeline_stage" {
+  type        = string
+  default     = "docker"
+  description = "Which pipeline_stage to use"
+  # See https://grafana.com/docs/loki/latest/clients/promtail/configuration/#pipeline_stages for options
+}

--- a/modules/grafana-agent-loki/daemonset.tf
+++ b/modules/grafana-agent-loki/daemonset.tf
@@ -5,8 +5,9 @@ resource "kubernetes_config_map" "grafana_agent_logs" {
 
   data = {
     "agent.yaml" = templatefile("${path.module}/agent-daemonset.yaml", {
-      LOKI_USERNAME = var.loki_username
-      LOKI_HOSTNAME = var.loki_hostname
+      LOKI_USERNAME  = var.loki_username
+      LOKI_HOSTNAME  = var.loki_hostname
+      pipeline_stage = var.pipeline_stage
     })
   }
 }


### PR DESCRIPTION
This allows configuring another pipeline_stage than the default docker
one.

This is useful when collecting logs from CRIs other than docker, which
use the "cri" log format.

See https://github.com/grafana/agent/issues/717#issuecomment-875587164
for context.