### PR TITLE
grafana-agent-daemonset: make namespaces for kube-state-metrics and node-exporter configurable

### DIFF
--- a/modules/grafana-agent/agent-daemonset.yaml
+++ b/modules/grafana-agent/agent-daemonset.yaml
@@ -76,11 +76,11 @@ prometheus:
                 regex: Succeeded|Failed
                 source_labels:
                   - __meta_kubernetes_pod_phase
-          - job_name: ${NAMESPACE}/kube-state-metrics
+          - job_name: ${NAMESPACE_KUBE_STATE_METRICS}/kube-state-metrics
             kubernetes_sd_configs:
               - namespaces:
                     names:
-                      - ${NAMESPACE}
+                      - ${NAMESPACE_KUBE_STATE_METRICS}
                 role: pod
             relabel_configs:
               - action: keep
@@ -94,11 +94,11 @@ prometheus:
                   - __meta_kubernetes_pod_container_name
                   - __meta_kubernetes_pod_container_port_name
                 target_label: instance
-          - job_name: ${NAMESPACE}/node-exporter
+          - job_name: ${NAMESPACE_NODE_EXPORTER}/node-exporter
             kubernetes_sd_configs:
               - namespaces:
                     names:
-                      - ${NAMESPACE}
+                      - ${NAMESPACE_NODE_EXPORTER}
                 role: pod
             relabel_configs:
               - action: keep

--- a/modules/grafana-agent/daemonset.tf
+++ b/modules/grafana-agent/daemonset.tf
@@ -4,10 +4,11 @@ resource "kubernetes_config_map" "grafana_agent_daemonset" {
   }
   data = {
     "agent.yml" = templatefile("${path.module}/agent-daemonset.yaml", {
-      REMOTE_WRITE_URL      = var.remote_write_url
-      REMOTE_WRITE_USERNAME = var.remote_write_username
-      NAMESPACE             = "default"
-      EXTERNAL_LABELS       = var.external_labels
+      REMOTE_WRITE_URL             = var.remote_write_url
+      REMOTE_WRITE_USERNAME        = var.remote_write_username
+      NAMESPACE_KUBE_STATE_METRICS = var.k8s_namespace_kube_state_metrics
+      NAMESPACE_NODE_EXPORTER      = "default" # this module deploys this in default right now
+      EXTERNAL_LABELS              = var.external_labels
     })
   }
 }

--- a/modules/grafana-agent/grafana_agent.tf
+++ b/modules/grafana-agent/grafana_agent.tf
@@ -11,3 +11,8 @@ variable "external_labels" {
   type    = map(string)
   default = {}
 }
+variable "k8s_namespace_kube_state_metrics" {
+  type        = string
+  default     = "default"
+  description = "Namespace that kube-state-metrics is deployed in"
+}


### PR DESCRIPTION
The upstream config file only scrapes for kube-state-metrics in the
$NAMESPACE namespace (hardcoded to default upstream) - but that isn't
necessarily the namespace that kube-state-metrics is deployed in, as
it's out of control of grafana-agent.

node-exporter is depoyed by grafana-agent, so it's less worrysome - we
still update the variable in the config file for consistency.