### PR TITLE
grafana-agent: fix proxy/metrics[/cadvisor] metrics collection

### DIFF
--- a/modules/grafana-agent/agent-daemonset.yaml
+++ b/modules/grafana-agent/agent-daemonset.yaml
@@ -123,7 +123,7 @@ prometheus:
               - replacement: https
                 target_label: __scheme__
               - regex: (.+)
-                replacement: /api/v1/nodes/$${1}/proxy/metrics
+                replacement: /api/v1/nodes/$1/proxy/metrics
                 source_labels:
                   - __meta_kubernetes_node_name
                 target_label: __metrics_path__
@@ -148,7 +148,7 @@ prometheus:
               - replacement: kubernetes.default.svc.cluster.local:443
                 target_label: __address__
               - regex: (.+)
-                replacement: /api/v1/nodes/$${1}/proxy/metrics/cadvisor
+                replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
                 source_labels:
                   - __meta_kubernetes_node_name
                 target_label: __metrics_path__


### PR DESCRIPTION
This should be the literal $1 string, so grafana-agent puts the node
name inside at runtime.

Before, it ended up as ${1}, which wasn't properly replaced at runtime:

ts=2021-07-12T15:03:32.978208431Z level=debug agent=prometheus instance=e47772ed8fb862eca50ef96d3664faf9 component="scrape manager" scrape_pool=kube-system/cadvisor target=https://kubernetes.default.svc.cluster.local:443/api/v1/nodes//proxy/metrics/cadvisor msg="Scrape failed" err="server returned HTTP status 403 Forbidden"