### PR TITLE
grafana-agent*: 0.16.0->0.16.1->0.17.0

### DIFF
--- a/modules/grafana-agent-loki/daemonset.tf
+++ b/modules/grafana-agent-loki/daemonset.tf
@@ -72,7 +72,7 @@ resource "kubernetes_daemonset" "grafana_agent_logs" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.0"
+          image   = "grafana/agent:v0.16.1"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-loki/daemonset.tf
+++ b/modules/grafana-agent-loki/daemonset.tf
@@ -72,7 +72,7 @@ resource "kubernetes_daemonset" "grafana_agent_logs" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.1"
+          image   = "grafana/agent:v0.17.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-tempo/daemonset.tf
+++ b/modules/grafana-agent-tempo/daemonset.tf
@@ -52,7 +52,7 @@ resource "kubernetes_daemonset" "grafana_agent_traces" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.1"
+          image   = "grafana/agent:v0.17.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-tempo/daemonset.tf
+++ b/modules/grafana-agent-tempo/daemonset.tf
@@ -52,7 +52,7 @@ resource "kubernetes_daemonset" "grafana_agent_traces" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.0"
+          image   = "grafana/agent:v0.16.1"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent/daemonset.tf
+++ b/modules/grafana-agent/daemonset.tf
@@ -49,7 +49,7 @@ resource "kubernetes_daemonset" "grafana_agent_daemonset" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.1"
+          image   = "grafana/agent:v0.17.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 

--- a/modules/grafana-agent/daemonset.tf
+++ b/modules/grafana-agent/daemonset.tf
@@ -49,7 +49,7 @@ resource "kubernetes_daemonset" "grafana_agent_daemonset" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.0"
+          image   = "grafana/agent:v0.16.1"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 

--- a/modules/grafana-agent/deployment.tf
+++ b/modules/grafana-agent/deployment.tf
@@ -49,7 +49,7 @@ resource "kubernetes_deployment" "grafana_agent_deployment" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.1"
+          image   = "grafana/agent:v0.17.0"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 

--- a/modules/grafana-agent/deployment.tf
+++ b/modules/grafana-agent/deployment.tf
@@ -49,7 +49,7 @@ resource "kubernetes_deployment" "grafana_agent_deployment" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.16.0"
+          image   = "grafana/agent:v0.16.1"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yml", "-config.expand-env", "-prometheus.wal-directory=/tmp/agent/data"]
 


### PR DESCRIPTION
This bumps to the latest release.

I diffed the `production` folder, containing the kubernetes manifests.

Except for the image tags, there were no changes, so no changes in the terraform code are necessary.