### PR TITLE
grafana-agent-tempo: bump to 0.18.4, support tempo_endpoint_protocol

### DIFF
--- a/modules/grafana-agent-tempo/agent-daemonset.yaml
+++ b/modules/grafana-agent-tempo/agent-daemonset.yaml
@@ -8,6 +8,7 @@ tempo:
           endpoint = TEMPO_ENDPOINT,
           basic_auth = (TEMPO_USERNAME != "") ? { username = TEMPO_USERNAME, password = "$${TEMPO_PASSWORD}" } : {},
           retry_on_failure = { enabled = TEMPO_ENDPOINT_RETRY_ON_FAILURE}
+          protocol = TEMPO_ENDPOINT_PROTOCOL
         }], (TEMPO_ADDITIONAL_ENDPOINTS != []) ? TEMPO_ADDITIONAL_ENDPOINTS : []))}
         %{~ if jsonencode(TEMPO_ATTRIBUTES) != "{}" ~}
         attributes: ${jsonencode(TEMPO_ATTRIBUTES)}

--- a/modules/grafana-agent-tempo/daemonset.tf
+++ b/modules/grafana-agent-tempo/daemonset.tf
@@ -52,7 +52,7 @@ resource "kubernetes_daemonset" "grafana_agent_traces" {
 
         container {
           name    = "agent"
-          image   = "grafana/agent:v0.17.0"
+          image   = "grafana/agent:v0.18.4"
           command = ["/bin/agent"]
           args    = ["-config.file=/etc/agent/agent.yaml", "-config.expand-env"]
 

--- a/modules/grafana-agent-tempo/daemonset.tf
+++ b/modules/grafana-agent-tempo/daemonset.tf
@@ -11,6 +11,7 @@ resource "kubernetes_config_map" "grafana_agent_traces" {
       TEMPO_ATTRIBUTES                = var.tempo_attributes
       TEMPO_ENDPOINT_RETRY_ON_FAILURE = var.tempo_endpoint_retry_on_failure
       TEMPO_ENDPOINT_HEADERS          = var.tempo_endpoint_headers
+      TEMPO_ENDPOINT_PROTOCOL         = var.tempo_endpoint_protocol
       TEMPO_ADDITIONAL_ENDPOINTS      = var.tempo_additional_endpoints
     })
     "strategies.json" = "{\"default_strategy\": {\"param\": 0.001, \"type\": \"probabilistic\"}}"

--- a/modules/grafana-agent-tempo/variables.tf
+++ b/modules/grafana-agent-tempo/variables.tf
@@ -11,6 +11,11 @@ variable "tempo_endpoint_retry_on_failure" {
   default     = false
   description = "Whether to enable 'Retry on failure' for the default endpoint."
 }
+variable "tempo_endpoint_protocol" {
+  type        = string
+  default     = "grpc"
+  description = "The protocol to use when sending to the (first) endpoint. grpc/http."
+}
 variable "tempo_username" {
   type        = string
   description = "Username to use for basic auth. Set to empty string to disable basic auth."


### PR DESCRIPTION
This will allow sending traces in OTLP HTTP trace format (which only got introduced in 0.18.0).

We bump the version to 0.18.4, and then introduce the `tempo_endpoint_protocol` variable (which can be set to `http`, instead of the `grpc` default).